### PR TITLE
Add failing HTML check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # portfolio
+
+## Running Tests
+Execute `npm test` to run the HTML check.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "gsap": "^3.12.2"
+  },
+  "scripts": {
+    "test": "node test/index.test.js"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const htmlPath = path.join(__dirname, '..', 'index.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+if (html.includes('width-="')) {
+  console.error('index.html should not contain \"width-=\"');
+  process.exitCode = 1;
+} else {
+  console.log('index.html does not contain width-="');
+}
+


### PR DESCRIPTION
## Summary
- add a simple Node-based test runner
- document how to run tests
- wire `npm test` to the test runner

## Testing
- `npm test` *(fails: index.html should not contain "width-=")*

------
https://chatgpt.com/codex/tasks/task_e_684005ff8df8832680afc3a749a89f02